### PR TITLE
makes steps a scriptable object and lets people reference it in the inspector

### DIFF
--- a/Assets/VR4VET/Components/Tasks/Scripts/Step.cs
+++ b/Assets/VR4VET/Components/Tasks/Scripts/Step.cs
@@ -7,7 +7,9 @@ using UnityEngine;
 namespace Task
 {
     [System.Serializable]
-    public class Step
+
+    [CreateAssetMenu(fileName = "New Step", menuName = "Tasks/Step")]
+    public class Step : ScriptableObject
     {
         [SerializeField] private string _stepName;
         [SerializeField] [Range(1, 20)] private int _repetionNumber = 1;


### PR DESCRIPTION
```
 [CreateAssetMenu(fileName = "New Step", menuName = "Tasks/Step")]
    public class Step : ScriptableObject
```
This was previously a base class, but it has to be referenced in the subtask step list, in the inspector, so needs to be either MonoBehaviour or ScriptableObject.