### PR TITLE
Hold to open menu fix

### DIFF
--- a/Assets/VR4VET/Components/PauseMenu/PauseInput.inputactions
+++ b/Assets/VR4VET/Components/PauseMenu/PauseInput.inputactions
@@ -1,0 +1,45 @@
+{
+    "name": "PauseInput",
+    "maps": [
+        {
+            "name": "Default",
+            "id": "68fc2b07-74d0-4aaf-849a-a278002ef3c5",
+            "actions": [
+                {
+                    "name": "Menu",
+                    "type": "Value",
+                    "id": "761fe0b5-248c-4aa9-ba9e-1e59e85dfdf1",
+                    "expectedControlType": "DiscreteButton",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "19bf4baa-4f9f-4319-bb19-dc1f43e57255",
+                    "path": "<Keyboard>/0",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Menu",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1ba1f665-69a5-40ec-9965-5b4c39973860",
+                    "path": "<XRController>{RightHand}/menu",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Menu",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        }
+    ],
+    "controlSchemes": []
+}

--- a/Assets/VR4VET/Components/PauseMenu/PauseInput.inputactions.meta
+++ b/Assets/VR4VET/Components/PauseMenu/PauseInput.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: 3643ec762f7b29040bcf1e1f41812b6f
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 0
+  wrapperCodePath: 
+  wrapperClassName: 
+  wrapperCodeNamespace: 

--- a/Assets/VR4VET/Components/PauseMenu/Scripts/NewMenuManger.cs
+++ b/Assets/VR4VET/Components/PauseMenu/Scripts/NewMenuManger.cs
@@ -149,6 +149,10 @@ public class NewMenuManger : MonoBehaviour
     {
         for (float I = 0f; I < _holdtime; I += Time.deltaTime)
         {
+            // Yes, this is a try catch checking if it can log the context variable.
+            // Yes, this is to check if the user releases the button.
+            // Yes, this is extremely stupid.
+            // But, it's the only thing I got to work.
             try
             {
                 Debug.Log(context);

--- a/Assets/VR4VET/Components/PauseMenu/Scripts/NewMenuManger.cs
+++ b/Assets/VR4VET/Components/PauseMenu/Scripts/NewMenuManger.cs
@@ -3,6 +3,7 @@
  */
 
 using System.Collections;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -31,6 +32,7 @@ public class NewMenuManger : MonoBehaviour
     // public GameObject stateSaverComponent;
 
     private GameObject _savedStates;
+    [SerializeField]
     private bool _menuOpen = false;
     private float _holdtime = 1.5f;
 
@@ -129,48 +131,45 @@ public class NewMenuManger : MonoBehaviour
 
     public void PressHoldMenu(InputAction.CallbackContext context)
     {
-        if (_holdToOpen)
+        if (_holdToOpen && !_menuOpen)
         {
             if (context.started)
             {
-                StartCoroutine(HoldPause());
+                StartCoroutine(HoldPause(context));
             }
         }
-        else
+        else if (context.performed)
         {
             ToggleMenu();
         }
     }
 
     // Loading wheel to open the pause menu
-    private IEnumerator HoldPause()
+    private IEnumerator HoldPause(InputAction.CallbackContext context)
     {
         for (float I = 0f; I < _holdtime; I += Time.deltaTime)
         {
-            // Get left-handed device and its current state (pressed or not).
-            UnityEngine.XR.InputDevice _rightDevice = InputDevices.GetDeviceAtXRNode(XRNode.RightHand);
-            _rightDevice.TryGetFeatureValue(UnityEngine.XR.CommonUsages.primaryButton, out bool triggerValue);
-
-            // Fill LoadingWheel if trigger is pressed
-            if (triggerValue)
+            try
             {
-                LoadingWheel.fillAmount = I;
+                Debug.Log(context);
             }
+            catch(Exception e)
+            {
+                LoadingWheel.fillAmount = 0f;
+                I = 1.6f;
+                yield break;
+            }
+            
+            // Fill LoadingWheel if trigger is pressed
+            LoadingWheel.fillAmount = I;
+            
 
             // Open menu if it has been continuously pressed.
             if (I >= 1f)
             {
                 LoadingWheel.fillAmount = 0f;
-                I = _holdtime + 1;
-
-                PauseGame();
-            }
-
-            // If trigger is no longer pressed, reset the LoadingWheel.
-            if ((!triggerValue))
-            {
-                LoadingWheel.fillAmount = 0f;
-                I = 1.6f;
+                ToggleMenu();
+                yield break;
             }
             yield return null;
         }


### PR DESCRIPTION
Now makes the HoldToOpen toggle use the input context instead of being hardcoded.

The way I did it is probably not the best way to fix it, but it is the only thing I got to work.

Closes #204 