### PR TITLE
Fix Tooltips requiring UnityEditor

### DIFF
--- a/Assets/AddressableAssetsData/link.xml
+++ b/Assets/AddressableAssetsData/link.xml
@@ -1,0 +1,34 @@
+<linker>
+  <assembly fullname="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Task.Skill" preserve="all" />
+    <type fullname="Task.Subtask" preserve="all" />
+    <type fullname="Task.Task" preserve="all" />
+  </assembly>
+  <assembly fullname="Unity.Addressables, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" preserve="all">
+    <type fullname="UnityEngine.AddressableAssets.Addressables" preserve="all" />
+  </assembly>
+  <assembly fullname="Unity.Localization, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="UnityEngine.Localization.Locale" preserve="all" />
+    <type fullname="UnityEngine.Localization.Tables.AssetTable" preserve="all" />
+    <type fullname="UnityEngine.Localization.Tables.SharedTableData" preserve="all" />
+    <type fullname="UnityEngine.Localization.Tables.StringTable" preserve="all" />
+    <type fullname="UnityEngine.Localization.Metadata.AssetTypeMetadata" preserve="nothing" serialized="true" />
+    <type fullname="UnityEngine.Localization.Metadata.MetadataCollection" preserve="nothing" serialized="true" />
+    <type fullname="UnityEngine.Localization.Tables.DistributedUIDGenerator" preserve="nothing" serialized="true" />
+    <type fullname="UnityEngine.Localization.Tables.SharedTableData/SharedTableEntry" preserve="nothing" serialized="true" />
+    <type fullname="UnityEngine.Localization.LocaleIdentifier" preserve="nothing" serialized="true" />
+    <type fullname="UnityEngine.Localization.Tables.TableEntryData" preserve="nothing" serialized="true" />
+  </assembly>
+  <assembly fullname="Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" preserve="all">
+    <type fullname="UnityEngine.ResourceManagement.ResourceProviders.AssetBundleProvider" preserve="all" />
+    <type fullname="UnityEngine.ResourceManagement.ResourceProviders.BundledAssetProvider" preserve="all" />
+    <type fullname="UnityEngine.ResourceManagement.ResourceProviders.InstanceProvider" preserve="all" />
+    <type fullname="UnityEngine.ResourceManagement.ResourceProviders.LegacyResourcesProvider" preserve="all" />
+    <type fullname="UnityEngine.ResourceManagement.ResourceProviders.SceneProvider" preserve="all" />
+  </assembly>
+  <assembly fullname="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="UnityEngine.Object" preserve="all" />
+    <type fullname="UnityEngine.Sprite" preserve="all" />
+    <type fullname="UnityEngine.Texture2D" preserve="all" />
+  </assembly>
+</linker>

--- a/Assets/AddressableAssetsData/link.xml.meta
+++ b/Assets/AddressableAssetsData/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9cd6f5990467e8341a449db950755321
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VR4VET/Components/ToolTips/Scripts/TooltipManager.cs
+++ b/Assets/VR4VET/Components/ToolTips/Scripts/TooltipManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
-using UnityEditor;
 using System;
 
 // Main class.
@@ -56,7 +55,7 @@ public class TooltipManager : MonoBehaviour
 
     public TooltipScript InstantiateTooltip(Transform Parent, string Header, string Content, string StartState = "Open", bool RemoveHeader = false, bool Unclosable = false, bool FacePlayer = true, bool AlwaysAboveParent = true, bool CloseWhenDistant = false, float CloseThreshold = 10f)
     {
-        GameObject instTooltip = PrefabUtility.InstantiatePrefab(TooltipPrefab, Parent) as GameObject;
+        GameObject instTooltip = Instantiate(TooltipPrefab, Parent) as GameObject;
         TooltipScript InstTooltip = instTooltip.GetComponent<TooltipScript>();
         Debug.Log(InstTooltip);
         AddNewTooltip(InstTooltip);

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -163,6 +163,10 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: -4725437308299915138, guid: efc564812903f744da3d5ca8621eb950, type: 2}
+  - {fileID: 6944003072686510143, guid: 8dbb7755b900c4a4f88d3b3a572c20a9, type: 2}
+  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
@@ -182,6 +186,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
+    Android: com.Ntnu.VR4VETTemplate
     Standalone: com.Ntnu.VR4VET-Template
   buildNumber:
     Standalone: 0
@@ -272,7 +277,7 @@ PlayerSettings:
   useCustomBaseGradleTemplate: 0
   useCustomGradlePropertiesTemplate: 0
   useCustomProguardFile: 0
-  AndroidTargetArchitectures: 1
+  AndroidTargetArchitectures: 2
   AndroidTargetDevices: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}


### PR DESCRIPTION
<!--- Not useful for our project for the moment, but may be used later
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
--->
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Tooltips requires a UnityEditor extension, which means it can't be built into an app. The extension used is the PrefabUtility to instantiate prefabs.

* **What is the new behavior?** (if this is a feature change)
Now uses Instantiate instead of InstantiatePrefab, removing the need for UnityEditor.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Fixes #258 











