### PR TITLE
Input transcripted text into OpenAI API

### DIFF
--- a/Assets/VR4VET/Components/NPC/OpenAITest.cs
+++ b/Assets/VR4VET/Components/NPC/OpenAITest.cs
@@ -7,6 +7,7 @@ public class OpenAITest : MonoBehaviour
 {
 	private string api = "https://api.openai.com/v1/chat/completions";
 	private string key;
+	public string query;
 
 	void Start()
 	{
@@ -25,7 +26,10 @@ public class OpenAITest : MonoBehaviour
 
 	IEnumerator OpenAI()
 	{
-		string query = "Hei. Kan du hjelpe meg med fisking?";
+		while (query == null) {
+			yield return new WaitForSeconds(1);
+		}
+		Debug.Log($"Query: {query.GetType()}");
 		string jsonData = $"{{\"model\": \"gpt-4o-mini\", \"messages\": [{{\"role\": \"user\", \"content\": \"{query}\"}}], \"max_tokens\": 50}}";
 		using (UnityWebRequest request = new UnityWebRequest(api, "POST"))
 		{

--- a/Assets/VR4VET/Components/NPC/ReadInput.cs
+++ b/Assets/VR4VET/Components/NPC/ReadInput.cs
@@ -4,12 +4,13 @@ using System.IO;
 using UnityEngine;
 using UnityEngine.Networking;
 
-public class ReadInput : MonoBehaviour
+    public class ReadInput : MonoBehaviour
 {
     private string api = "https://api.openai.com/v1/audio/transcriptions";
     private string key;
+    public string transcript;
 
-	public string audioFile; // The audio file to send to OpenAI, must be in the StreamingAssets folder
+	public string audioFile = "test.wav"; // The audio file to send to OpenAI, must be in the StreamingAssets folder
 
 	public SupportedLanguage selectedLanguage;  // Public dropdown to select the language
 
@@ -97,6 +98,7 @@ public class ReadInput : MonoBehaviour
             else
             {
                 Debug.Log($"OpenAI Transcription Response: {request.downloadHandler.text}");
+                transcript = request.downloadHandler.text.Replace("{", "").Replace("\"", "").Replace(":", "").Replace("}", "").Trim();
             }
         }
     }

--- a/Assets/VR4VET/Components/NPC/SaveUserSpeech.cs
+++ b/Assets/VR4VET/Components/NPC/SaveUserSpeech.cs
@@ -5,6 +5,8 @@ using System.IO;
 using UnityEngine;
 using System.Collections.Generic;
 using System.Collections;
+using static ReadInput;
+using static OpenAITest;
 
 public class SaveUserSpeech : MonoBehaviour
 {	
@@ -25,6 +27,14 @@ public class SaveUserSpeech : MonoBehaviour
 		yield return new WaitForSeconds(5);
 		Debug.Log("TEEEEEEST");
 		SaveUserSpeech.Save("test", myAudioClip);
+		ReadInput ri = gameObject.AddComponent<ReadInput>() as ReadInput;
+		while (ri.transcript == null) {
+			yield return new WaitForSeconds(1);
+		}
+		Debug.Log($"Dette er fra SUS: {ri.transcript}");
+		OpenAITest oai = gameObject.AddComponent<OpenAITest>() as OpenAITest;
+		oai.query = ri.transcript;
+
 	}
 
     //	Copyright (c) 2012 Calvin Rien


### PR DESCRIPTION
Use ReadInput class to transcribe the audiofile generated in SaveUserSpeech, then use this transcript as a query to the OpenAI API using the OpenAITest class. For future development: Research how to only receive the content of the JSON response.

Issue Number: #284

Co-authored-by: nicoljn19 <nicoljn19@gmail.com>