### PR TITLE
Past conversation as context

### DIFF
--- a/Assets/VR4VET/Components/NPC/AI/AIConversationController.cs
+++ b/Assets/VR4VET/Components/NPC/AI/AIConversationController.cs
@@ -11,6 +11,8 @@ public class AIConversationController : MonoBehaviour
     public string contextPrompt;
     public int maxTokens = 50;
 
+    public List<Message> messages = new List<Message>();
+
     
 
     void Start()
@@ -27,5 +29,10 @@ public class AIConversationController : MonoBehaviour
     public void EndRecording()
     {
         _SaveUserSpeech.EndRecording();
+    }
+
+    public void AddMessage(Message message)
+    {
+        messages.Add(message);
     }
 }

--- a/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
+++ b/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
@@ -32,12 +32,6 @@ public class AIRequest : MonoBehaviour
         if (_AIConversationController != null)
         {
             messages = new List<Message>(_AIConversationController.messages);
-            if (messages.Count == 0)
-            {
-                Message promptMessage = new Message { role = "system", content = contextPrompt };
-                messages.Add(promptMessage);
-                _AIConversationController.AddMessage(promptMessage);
-            }
         }
         else
         {
@@ -102,6 +96,8 @@ public class AIRequest : MonoBehaviour
             request.downloadHandler = new DownloadHandlerBuffer();
             request.SetRequestHeader("Content-Type", "application/json");
             request.SetRequestHeader("Authorization", $"Bearer {key}");
+
+            Debug.Log(jsonData);    
 
             // Asynchronously send and wait for the response
             yield return request.SendWebRequest();

--- a/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
+++ b/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -13,18 +14,41 @@ public class AIRequest : MonoBehaviour
     public string responseText;
 
     public AIResponseToSpeech _AIResponseToSpeech; // Reference to AIResponseToSpeech script, for dictation
-    public DialogueBoxController _dialogueBoxController;  
+    public DialogueBoxController _dialogueBoxController;
+
+    public AIConversationController _AIConversationController; // Save messages here in order to save them across multiple instances of this AIrequset.
+
+    private List<Message> messages = new List<Message>();
+
 
     void Start()
     {
         // Get OpenAI key, which must be set in .env file
         key = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
 
+        _AIConversationController = GetComponent<AIConversationController>();
+
+        if (_AIConversationController != null)
+        {
+            messages = new List<Message>(_AIConversationController.messages);
+            if (messages.Count == 0)
+            {
+                Message promptMessage = new Message { role = "system", content = contextPrompt };
+                messages.Add(promptMessage);
+                _AIConversationController.AddMessage(promptMessage);
+            }
+        }
+        else
+        {
+            Debug.LogError("AIConversationController not found.");
+        }
+
         if (string.IsNullOrEmpty(key))
         {
             Debug.LogError("OpenAI API key not found.");
             return;
         }
+
         // Attempt to automatically find and set AIResponseToSpeech
         if (_AIResponseToSpeech == null)
         {
@@ -35,6 +59,7 @@ public class AIRequest : MonoBehaviour
                 return;
             }
         }
+
         if (_dialogueBoxController == null)
         {
             _dialogueBoxController = FindObjectOfType<DialogueBoxController>();
@@ -45,8 +70,12 @@ public class AIRequest : MonoBehaviour
             }
         }
 
-    // Start coroutine for the OpenAI request
-    StartCoroutine(OpenAI());
+        Message userMessage = new Message { role = "user", content = query };
+        messages.Add(userMessage);
+        _AIConversationController.AddMessage(userMessage);
+
+        // Start coroutine for the OpenAI request
+        StartCoroutine(OpenAI());
     }
 
     IEnumerator OpenAI()
@@ -55,11 +84,16 @@ public class AIRequest : MonoBehaviour
         {
             yield return new WaitForSeconds(0.01f);
         }
-        // Debug.Log($"Query: {query}");
 
-        // Creates the OpenAI API request in JSON format, with the query from the user inserted
-        string jsonData = $"{{\"model\": \"gpt-4o-mini\", \"messages\": [{{\"role\": \"user\", \"content\": \"{contextPrompt} input:{query}\"}}], \"max_tokens\": {maxTokens}}}";
-        Debug.Log($"context: {contextPrompt} q: {query}");
+        OpenAIRequest openAIRequest = new OpenAIRequest
+        {
+            model = "gpt-4o-mini",
+            messages = messages,
+            max_tokens = maxTokens
+        };
+
+        string jsonData = JsonUtility.ToJson(openAIRequest);
+
         using (UnityWebRequest request = new UnityWebRequest(api, "POST"))
         {
             byte[] bodyRaw = new System.Text.UTF8Encoding().GetBytes(jsonData);
@@ -81,11 +115,14 @@ public class AIRequest : MonoBehaviour
 
                 // Retrieve the field with the actual response content, but add backslash before problematic characters
                 responseText = response.choices[0].message.content
-						.Replace("\\", "\\\\") 
-    					.Replace("\"", "\\\"") 
-    					.Replace("\n", "\\n")   
-    					.Replace("\r", "\\r");
-                Debug.Log($"Response: {responseText}");
+                    .Replace("\\", "\\\\")
+                    .Replace("\"", "\\\"")
+                    .Replace("\n", "\\n")
+                    .Replace("\r", "\\r");
+
+                Message assistantMessage = new Message { role = "assistant", content = responseText };
+                messages.Add(assistantMessage);
+                _AIConversationController.AddMessage(assistantMessage);
 
                 // Call AIResponseToSpeech to dictate the response
                 if (_AIResponseToSpeech != null)

--- a/Assets/VR4VET/Components/NPC/AI/OpenAIResponseSerializer.cs
+++ b/Assets/VR4VET/Components/NPC/AI/OpenAIResponseSerializer.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+
 
 // Field definitions for all of our serializable structures, for JSON requests and responses
 [Serializable]
@@ -40,7 +42,15 @@ public class OpenAIResponse
 	public string object_;
 	public string created;
 	public string model;
-	public Choice[] choices;
+	public List<Choice> choices;
 	public Usage usage;
 	public string system_fingerprint;
+}
+
+[Serializable]
+public class OpenAIRequest
+{
+    public string model;
+    public List<Message> messages;
+    public int max_tokens;
 }

--- a/Assets/VR4VET/Components/NPC/NPCExamples/AIAssistant.asset
+++ b/Assets/VR4VET/Components/NPC/NPCExamples/AIAssistant.asset
@@ -29,5 +29,7 @@ MonoBehaviour:
     type: 2}
   SpatialBlend: 0
   MinDistance: 0
-  contextPrompt: You are bob the builder!
-  maxTokens: 50
+  contextPrompt: 'You are an AI assistant NPC in a VR game. You are listening and
+    talking via TTS and STT. Your name is mr. AI! Be helpful and give give short
+    answers. '
+  maxTokens: 1000

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -35,6 +35,8 @@ public class DialogueBoxController : MonoBehaviour
 
     public AIResponseToSpeech _AIResponseToSpeech; // Reference to AIResponseToSpeech script, for dictation
 
+    public AIConversationController _AIConversationController; // Save messages here in order to save them across multiple instances of this AIrequset.
+
     public bool useWitAI;
 
     private void Awake()
@@ -94,6 +96,15 @@ public class DialogueBoxController : MonoBehaviour
                 return;
             }
         }
+
+        if (_AIConversationController == null)
+        {
+            _AIConversationController = FindObjectOfType<AIConversationController>();
+            if (_AIConversationController == null)
+            {
+                Debug.LogError("AIConversationController component not found.");
+            }
+        }
     }
 
     public void updateAnimator()
@@ -141,6 +152,7 @@ public class DialogueBoxController : MonoBehaviour
             _animator.SetBool(_isTalkingHash, true);
             StartCoroutine(revertToIdleAnimation());
             _dialogueText.text = dialogueTree.sections[section].dialogue[i];
+            AddDialogueToContext(_dialogueText.text);
             if (useWitAI)
             {
                 TTSSpeaker.GetComponent<TTSSpeaker>().Speak(_dialogueText.text);
@@ -166,7 +178,7 @@ public class DialogueBoxController : MonoBehaviour
             StartDynamicQuery();
             yield break;
         }
-        _dialogueText.text = dialogueTree.sections[section].branchPoint.question;
+
         if (useWitAI)
         {
             TTSSpeaker.GetComponent<TTSSpeaker>().Speak(_dialogueText.text);
@@ -242,6 +254,13 @@ public class DialogueBoxController : MonoBehaviour
         _exitButton.SetActive(false);
     }
 
+    void AddDialogueToContext(string dialogue)
+    {
+        _AIConversationController.AddMessage(new Message { role = "assistant", content = dialogue });
+        Debug.Log("Added message to context: " + dialogue);
+
+    }
+
     void ShowAnswers(BranchPoint branchPoint)
     {
         // Reveals the selectable answers and sets their text values
@@ -305,6 +324,7 @@ public class DialogueBoxController : MonoBehaviour
 
         // Set text to generic question
         _dialogueText.text = "That's all I have to say. Do you have any questions? Hold B to speak to me.";
+
 
         // NPC will speak generic question
         if (useWitAI)

--- a/Assets/VR4VET/Components/NPC/Scripts/NPC.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/NPC.cs
@@ -23,6 +23,6 @@ public class NPC : ScriptableObject
 
     [TextArea(3, 10)]
     public string contextPrompt;
-    public int maxTokens=50;
+    public int maxTokens=1000;
     
 }

--- a/Assets/VR4VET/Components/NPC/Scripts/NPCSpawner.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/NPCSpawner.cs
@@ -135,6 +135,9 @@ public class NPCSpawner : MonoBehaviour
         } else {
             aiConversationController.contextPrompt = contextPrompt;
             aiConversationController.maxTokens = maxTokens;
+            
+            Message promptMessage = new Message { role = "system", content = contextPrompt };
+            aiConversationController.AddMessage(promptMessage);
         }
     }
 


### PR DESCRIPTION
Enhance NPC interactions by passing past conversations as context in AIRequest.

By incorporating past dialogues as context, the AI can generate more relevant and coherent responses, improving the overall user experience.

Issue Number: #320