### PR TITLE
Hide dialogue box when player exits proximity

### DIFF
--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ConversationController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/ConversationController.cs
@@ -93,23 +93,16 @@ public class ConversationController : MonoBehaviour
         {
             playerInsideTrigger = true;
             Debug.Log("Inside range to talk.");
-        }
-        if (other.Equals(NPCToPlayerReferenceManager.Instance.PlayerCollider) && _dialogueTree.shouldTriggerOnProximity && !_dialogueBoxController.dialogueIsActive && _oldDialogueTree != _dialogueTree)
-        {
 
-            // string json = JsonUtility.ToJson(dialogueTree);
-            // Debug.Log(json);
-            //_dialogueBoxController.startSpeakCanvas(_dialogueTree);
-            _oldDialogueTree = _dialogueTree;
-            if (_dialogueTree != null)
+            // Show dialogue box
+            _dialogueBoxController.ShowDialogueBox();
+            if (_dialogueTree.shouldTriggerOnProximity && !_dialogueBoxController.dialogueIsActive && _oldDialogueTree != _dialogueTree)
             {
-                _dialogueBoxController.StartDialogue(_dialogueTree, 0, "NPC");
-            }
-            else
-            {
-                // Commented out because not all NPC's should have a dialogue tree, therefor not an error
-
-                //Debug.LogError("The dialogueTree of the NPC is null");
+                _oldDialogueTree = _dialogueTree;
+                if (_dialogueTree != null)
+                {
+                    _dialogueBoxController.StartDialogue(_dialogueTree, 0, "NPC");
+                }
             }
         }
     }
@@ -120,6 +113,7 @@ public class ConversationController : MonoBehaviour
         {
             playerInsideTrigger = false;
             Debug.Log("Outside range to talk.");
+            _dialogueBoxController.HideDialogueBox();
         }
     }
 

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -402,4 +402,18 @@ public class DialogueBoxController : MonoBehaviour
         _animator.SetBool(_isListeningHash, false);
     }
 
+    public void ShowDialogueBox()
+    {
+        _dialogueBox.SetActive(true);
+        _dialogueCanvas.SetActive(true);
+        Debug.Log("Dialogue box reactivated.");
+    }
+
+    public void HideDialogueBox()
+    {
+        _dialogueBox.SetActive(false);
+        _dialogueCanvas.SetActive(false);
+        Debug.Log("Dialogue box hidden.");
+    }
+
 }


### PR DESCRIPTION
Now the dialogue box is hidden if the player exits proximity after entering it. If the player re-enters then it is toggled on again.

Issue Number: #345