### PR TITLE
Limit the amount of text shown in dialogue box

### DIFF
--- a/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
+++ b/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
@@ -112,10 +112,21 @@ public class AIRequest : MonoBehaviour
 
                 // Retrieve the field with the actual response content, but add backslash before problematic characters
                 responseText = response.choices[0].message.content
-                    .Replace("\\", "\\\\")
-                    .Replace("\"", "\\\"")
-                    .Replace("\n", "\\n")
-                    .Replace("\r", "\\r");
+                    .Replace("\\", "")
+                    .Replace("\"", "")
+                    .Replace("\n", "")
+                    .Replace("*", "")
+                    .Replace("[", "")
+                    .Replace("]", "")
+                    .Replace("_", "")
+                    .Replace("#", "")
+                    .Replace("\r", "");
+
+            if (responseText.Length > 280)
+            {
+                responseText = responseText.Substring(0, 280);
+                responseText = $"{responseText}...";
+            }
 
                 Message assistantMessage = new Message { role = "assistant", content = responseText };
                 messages.Add(assistantMessage);

--- a/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
+++ b/Assets/VR4VET/Components/NPC/AI/AIRequest.cs
@@ -122,12 +122,6 @@ public class AIRequest : MonoBehaviour
                     .Replace("#", "")
                     .Replace("\r", "");
 
-            if (responseText.Length > 280)
-            {
-                responseText = responseText.Substring(0, 280);
-                responseText = $"{responseText}...";
-            }
-
                 Message assistantMessage = new Message { role = "assistant", content = responseText };
                 messages.Add(assistantMessage);
                 _AIConversationController.AddMessage(assistantMessage);
@@ -143,6 +137,12 @@ public class AIRequest : MonoBehaviour
                     StopCoroutine(thinking);
                     _dialogueBoxController.stopThinking();
 
+                    if (responseText.Length > 280)
+                    {
+                        responseText = responseText.Substring(0, 280);
+                        responseText = $"{responseText}...";
+                    }
+
                     // Display the response in the dialogue box
                     StartCoroutine(_dialogueBoxController.DisplayResponse(responseText));
                 }
@@ -154,6 +154,13 @@ public class AIRequest : MonoBehaviour
                     Coroutine thinking = StartCoroutine(_dialogueBoxController.DisplayThinking());
                     yield return new WaitUntil(() => _AIResponseToSpeech.readyToAnswer);
                     StopCoroutine(thinking);
+                    _dialogueBoxController.stopThinking();
+
+                    if (responseText.Length > 280)
+                    {
+                        responseText = responseText.Substring(0, 280);
+                        responseText = $"{responseText}...";
+                    }
 
                     // Display the response in the dialogue box
                     StartCoroutine(_dialogueBoxController.DisplayResponse(responseText));

--- a/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
+++ b/Assets/VR4VET/Components/NPC/Scripts/DialogueTree/DialogueBoxController.cs
@@ -159,6 +159,11 @@ public class DialogueBoxController : MonoBehaviour
             // Start talking animation
             StartCoroutine(revertToIdleAnimation());
             _dialogueText.text = dialogueTree.sections[section].dialogue[i];
+            if (_dialogueText.text.Length > 280)
+            {
+                _dialogueText.text = _dialogueText.text.Substring(0, 280);
+                _dialogueText.text = $"{_dialogueText.text}...";
+            }
             AddDialogueToContext(_dialogueText.text);
             if (useWitAI)
             {
@@ -333,8 +338,7 @@ public class DialogueBoxController : MonoBehaviour
         _dialogueBox.SetActive(true);
 
         // Set text to generic question
-        _dialogueText.text = "Now you know the basics. That's all I have to say.";
-
+        _dialogueText.text = "That is all I have to say.";
 
         // NPC will speak generic question
         if (useWitAI)


### PR DESCRIPTION
Only the first 280 characters of responses and dialogue are displayed now, with "..." added at the end if it is cut off.

Issue Number: #347